### PR TITLE
Harden asset loading and clean up analytics warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/new_site (1)/analytics.html
+++ b/new_site (1)/analytics.html
@@ -8,15 +8,31 @@
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha256-HtsXJanqjKTc8vVQjO4YMhiqFoXkfBsjBWcX91T1jr8="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />
   <!-- Leaflet CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+    crossorigin="anonymous"
+  />
   
   <!-- Leaflet MarkerCluster CSS -->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css" />
-  <link rel="stylesheet" href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.css"
+    integrity="sha256-+bdWuWOXMFkX0v9Cvr3OWClPiYefDQz9GGZP/7xZxdc="
+    crossorigin="anonymous"
+  />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet.markercluster@1.4.1/dist/MarkerCluster.Default.css"
+    integrity="sha256-LWhzWaQGZRsWFrrJxg+6Zn8TT84k0/trtiHBc6qcGpY="
+    crossorigin="anonymous"
+  />
   
   <!-- Custom CSS -->
   <link rel="stylesheet" href="styles.css" />
@@ -197,12 +213,21 @@
   <!-- Leaflet library for map rendering -->
   <script
     src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
-    crossorigin=""
+    integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+    crossorigin="anonymous"
   ></script>
   <!-- Leaflet MarkerCluster for clustering functionality -->
-  <script src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"></script>
+  <script
+    src="https://unpkg.com/leaflet.markercluster@1.4.1/dist/leaflet.markercluster.js"
+    integrity="sha256-WL6HHfYfbFEkZOFdsJQeY7lJG/E5airjvqbznghUzRw="
+    crossorigin="anonymous"
+  ></script>
   <!-- Leaflet.heat for heatmap functionality -->
-  <script src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"></script>
+  <script
+    src="https://unpkg.com/leaflet.heat@0.2.0/dist/leaflet-heat.js"
+    integrity="sha256-65UqrlgGoRAnKfKRuriH3eeDrOhZgZo1SCenduc+SGo="
+    crossorigin="anonymous"
+  ></script>
   <script src="analytics.js"></script>
 </body>
 </html>

--- a/new_site (1)/analytics.js
+++ b/new_site (1)/analytics.js
@@ -1590,21 +1590,33 @@ function updateInsights(metrics) {
     // Add coordinate quality warning to the page
     const qualityWarning = document.getElementById('coordinateQualityWarning');
     if (qualityWarning) {
+      qualityWarning.textContent = '';
       if (validPct < 5) {
-        qualityWarning.innerHTML = `
-          <div style="background: rgba(239, 68, 68, 0.1); border: 1px solid rgba(239, 68, 68, 0.3); border-radius: 8px; padding: 12px; margin: 16px 0; color: #fca5a5;">
-            <strong>⚠️ Data Quality Notice:</strong> Only ${validPct}% of reports have accurate coordinates. 
-            ${placeholderPct}% use placeholder coordinates (37.0902, -95.7129). 
-            Geographic analysis may be limited.
-          </div>
-        `;
+        const div = document.createElement('div');
+        div.style.background = 'rgba(239, 68, 68, 0.1)';
+        div.style.border = '1px solid rgba(239, 68, 68, 0.3)';
+        div.style.borderRadius = '8px';
+        div.style.padding = '12px';
+        div.style.margin = '16px 0';
+        div.style.color = '#fca5a5';
+        const strong = document.createElement('strong');
+        strong.textContent = '⚠️ Data Quality Notice:';
+        div.appendChild(strong);
+        div.appendChild(document.createTextNode(` Only ${validPct}% of reports have accurate coordinates. ${placeholderPct}% use placeholder coordinates (37.0902, -95.7129). Geographic analysis may be limited.`));
+        qualityWarning.appendChild(div);
       } else if (validPct < 20) {
-        qualityWarning.innerHTML = `
-          <div style="background: rgba(245, 158, 11, 0.1); border: 1px solid rgba(245, 158, 11, 0.3); border-radius: 8px; padding: 12px; margin: 16px 0; color: #fbbf24;">
-            <strong>📊 Data Quality Notice:</strong> ${validPct}% of reports have accurate coordinates. 
-            Geographic analysis available but limited.
-          </div>
-        `;
+        const div = document.createElement('div');
+        div.style.background = 'rgba(245, 158, 11, 0.1)';
+        div.style.border = '1px solid rgba(245, 158, 11, 0.3)';
+        div.style.borderRadius = '8px';
+        div.style.padding = '12px';
+        div.style.margin = '16px 0';
+        div.style.color = '#fbbf24';
+        const strong = document.createElement('strong');
+        strong.textContent = '📊 Data Quality Notice:';
+        div.appendChild(strong);
+        div.appendChild(document.createTextNode(` ${validPct}% of reports have accurate coordinates. Geographic analysis available but limited.`));
+        qualityWarning.appendChild(div);
       }
     }
   } else {

--- a/new_site (1)/blog.html
+++ b/new_site (1)/blog.html
@@ -8,6 +8,7 @@
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha256-HtsXJanqjKTc8vVQjO4YMhiqFoXkfBsjBWcX91T1jr8="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />

--- a/new_site (1)/data.html
+++ b/new_site (1)/data.html
@@ -8,6 +8,7 @@
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha256-HtsXJanqjKTc8vVQjO4YMhiqFoXkfBsjBWcX91T1jr8="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />

--- a/new_site (1)/index.html
+++ b/new_site (1)/index.html
@@ -9,6 +9,7 @@
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha256-HtsXJanqjKTc8vVQjO4YMhiqFoXkfBsjBWcX91T1jr8="
     crossorigin="anonymous"
     referrerpolicy="no-referrer"
   />

--- a/new_site (1)/script.js
+++ b/new_site (1)/script.js
@@ -3,9 +3,9 @@
 //
 // This file powers the dynamic portions of the Alien Encounters website.
 // It loads the UFO sightings CSV, populates the interactive data table,
-// computes aggregate statistics and renders charts using Chart.js. When
-// modifying this file, take care to keep functions modular and avoid
-// polluting the global namespace.
+// computes aggregate statistics and renders charts using lightweight
+// DOM elements. When modifying this file, take care to keep functions
+// modular and avoid polluting the global namespace.
 
 document.addEventListener('DOMContentLoaded', () => {
   // Use the globally defined nuforcData array provided by nuforc-2025-07-02.js


### PR DESCRIPTION
## Summary
- add `.gitignore` to stop tracking node modules
- secure CDN assets with Subresource Integrity and anonymous cross-origin settings
- replace risky `innerHTML` chart warnings with safe DOM construction
- clarify that charts render via DOM elements rather than Chart.js

## Testing
- `npm test` (fails: Missing script "test")


------
https://chatgpt.com/codex/tasks/task_e_689c62bfdb90832b89450cbe255e18ff