### PR TITLE
Add meta descriptions to site pages

### DIFF
--- a/new_site (1)/analytics.html
+++ b/new_site (1)/analytics.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Analyze UFO sightings and alien encounters with interactive charts and maps." />
   <title>UFO Analytics | Alien Encounters</title>
   <!-- Font Awesome -->
   <link

--- a/new_site (1)/blog.html
+++ b/new_site (1)/blog.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Read stories and insights about UFO sightings, alien encounters, and extraterrestrial theories." />
   <title>Alien Insights Blog | Alien Encounters</title>
   <!-- Font Awesome -->
   <link

--- a/new_site (1)/data.html
+++ b/new_site (1)/data.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Browse real UFO sightings and alien encounter reports using interactive search and filters." />
   <title>UFO Sightings Data | Alien Encounters</title>
   <!-- Font Awesome for icons -->
   <link


### PR DESCRIPTION
## Summary
- add meta description tags for data, analytics, and blog pages to standardize tone and include UFO-related keywords

## Testing
- `cd 'new_site (1)' && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689dd2923174832ba613c4694633ff11