### PR TITLE
Improve hero layout and map overlay

### DIFF
--- a/ANCIENT ALIENS/index.html
+++ b/ANCIENT ALIENS/index.html
@@ -36,16 +36,13 @@
 
   <main id="main-content">
   <!-- Hero section -->
-  <section class="hero">
+  <section class="hero" role="img" aria-label="Cosmic landscape with constellations">
       <div class="hero-content">
         <h1>Archaeology, myths and technology out of time</h1>
         <p class="subtitle">
           Dive into a data‑driven exploration of humanity’s oldest mysteries.
         </p>
         <a class="btn" href="evidence.html">Explore the evidence</a>
-      </div>
-      <div class="hero-image">
-        <img src="public/images/hero.png" alt="Cosmic landscape with constellations" loading="lazy" />
       </div>
     </section>
 

--- a/ANCIENT ALIENS/style.css
+++ b/ANCIENT ALIENS/style.css
@@ -96,18 +96,27 @@ header nav a:hover {
 
 /* Hero section */
 .hero {
+  position: relative;
   display: flex;
-  flex-direction: column-reverse;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1rem 3rem;
+  padding: 6rem 1rem;
+  text-align: center;
   border-bottom: 1px solid var(--border);
+  background: url("public/images/hero.png") center/cover no-repeat;
+}
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
 }
 
 .hero-content {
+  position: relative;
+  z-index: 1;
   max-width: 600px;
-  text-align: center;
-  margin-top: 2rem;
 }
 
 .hero h1 {
@@ -139,19 +148,13 @@ header nav a:hover {
   color: #0b0f14;
 }
 
-.hero-image img {
-  width: 100%;
-  max-width: 900px;
-  border-radius: 8px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
-}
 
 /* Anchor cards */
 .anchors {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-  padding: 2rem 1rem;
+  gap: 1.5rem;
+  padding: 3rem 1rem;
   max-width: 1100px;
   margin: 0 auto;
 }
@@ -315,7 +318,15 @@ header nav a:hover {
 .map-container img {
   width: 100%;
   border-radius: 6px;
-  opacity: 0.6;
+  display: block;
+}
+
+.map-container::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.4);
 }
 .map-overlay {
   position: absolute;
@@ -328,6 +339,7 @@ header nav a:hover {
   align-items: center;
   justify-content: center;
   color: var(--text);
+  z-index: 1;
 }
 .map-overlay span {
   margin-bottom: 0.5rem;


### PR DESCRIPTION
## Summary
- Convert home page hero image to CSS background with dark overlay
- Increase anchor-card spacing for better readability
- Replace mini map opacity with overlay for improved contrast

## Testing
- `npx htmlhint 'ANCIENT ALIENS/index.html'`
- `npx html-validate 'ANCIENT ALIENS/index.html'` *(fails: Expected omitted end tag <meta> instead of self-closing element)*

------
https://chatgpt.com/codex/tasks/task_e_68adfe0984b4832b94140a41a437d98a