### PR TITLE
Add interactive Leaflet map to atlas page

### DIFF
--- a/ANCIENT ALIENS/atlas.html
+++ b/ANCIENT ALIENS/atlas.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Atlas – XenoOrigin</title>
   <link rel="stylesheet" href="style.css">
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-xodZBNTC5n17Xt2atTPuE1HxjVMSvLVW9ocqUKLsCC0="
+    crossorigin="" />
   <meta property="og:title" content="Atlas – XenoOrigin">
   <meta property="og:description" content="Interactive atlas of ancient sites, artefacts and modern sighting clusters (coming soon).">
   <meta property="og:type" content="website">
@@ -35,19 +40,7 @@
     <h1>Atlas</h1>
     <p>The Atlas will display an interactive world map with clustered pins for megaliths, geoglyphs, artefacts, texts and modern sightings.  Each pin opens a micro‑card with key metrics and links to the full evidence page.</p>
 
-    <section class="map-placeholder">
-      <h2>Map Placeholder</h2>
-      <p>The interactive map is under development.  Below is a list of sample locations included in the Atlas:</p>
-      <ul>
-        <li>Great Pyramid of Giza – Egypt (Africa)</li>
-        <li>Baalbek – Lebanon (Asia)</li>
-        <li>Pumapunku – Bolivia (Americas)</li>
-        <li>Stonehenge – United Kingdom (Europe)</li>
-        <li>Nazca Lines – Peru (Americas)</li>
-        <li>Antikythera Shipwreck – Greece (Europe)</li>
-        <li>Nuremberg Sky Event – Germany (Europe)</li>
-      </ul>
-    </section>
+    <div id="map" aria-label="Interactive map of ancient sites"></div>
   </main>
 
   <footer class="site-footer">
@@ -56,6 +49,10 @@
     </div>
   </footer>
 
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-pHQKHB17VEpEt3gjYsHDzM3xPUfNQ4G08EkMced/JFI="
+    crossorigin=""></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/ANCIENT ALIENS/script.js
+++ b/ANCIENT ALIENS/script.js
@@ -20,3 +20,27 @@ function subscribe(event) {
 }
 
 // Future hooks: simple page toggles or comparator logic can be added here.
+
+document.addEventListener('DOMContentLoaded', () => {
+  const mapEl = document.getElementById('map');
+  if (mapEl && typeof L !== 'undefined') {
+    const map = L.map('map').setView([20, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors'
+    }).addTo(map);
+
+    const sites = [
+      { coords: [29.9792, 31.1342], label: 'Great Pyramid of Giza' },
+      { coords: [34.006, 36.2038], label: 'Baalbek' },
+      { coords: [-16.561, -68.6804], label: 'Pumapunku' },
+      { coords: [51.1789, -1.8262], label: 'Stonehenge' },
+      { coords: [-14.739, -75.13], label: 'Nazca Lines' },
+      { coords: [35.9411, 26.2747], label: 'Antikythera Shipwreck' },
+      { coords: [49.4521, 11.0767], label: 'Nuremberg Sky Event' }
+    ];
+
+    sites.forEach(site => {
+      L.marker(site.coords).addTo(map).bindPopup(site.label);
+    });
+  }
+});

--- a/ANCIENT ALIENS/style.css
+++ b/ANCIENT ALIENS/style.css
@@ -734,3 +734,12 @@ table tr:nth-child(even) {
     max-width: 50%;
   }
 }
+
+/* Atlas map */
+#map {
+  height: 480px;
+  width: 100%;
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}


### PR DESCRIPTION
## Summary
- Replace atlas placeholder with a Leaflet-driven interactive map
- Style map container for consistent layout
- Initialize map and sample markers with Leaflet

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68ae0360ce24832b8d76a3488a032a86